### PR TITLE
Device

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>0.2.3</VersionPrefix>
+    <VersionPrefix>0.2.4</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/FibaroDotNetSDK/Devices/DeviceGateway.cs
+++ b/src/FibaroDotNetSDK/Devices/DeviceGateway.cs
@@ -21,6 +21,12 @@ namespace FibaroDotNetSDK.Devices
             return _client.SendRequest<ICollection<Device>>(request);
         }
 
+        public Task<Device> GetDeviceById(int deviceId)
+        {
+            var request = new GetDeviceByIdRequest(deviceId);
+            return _client.SendRequest<Device>(request);
+        }
+
         public Task Call(long id, DeviceAction action)
         {
             var request = new CallDeviceActionRequest(id, action);

--- a/src/FibaroDotNetSDK/Devices/GetDeviceByIdRequest.cs
+++ b/src/FibaroDotNetSDK/Devices/GetDeviceByIdRequest.cs
@@ -1,0 +1,13 @@
+﻿using System.Net.Http;
+using FibaroDotNetSDK.Infrastructure;
+
+namespace FibaroDotNetSDK.Devices
+{
+    public class GetDeviceByIdRequest : RequestBase
+    {
+        public GetDeviceByIdRequest(int deviceId)
+            : base(HttpMethod.Get, $"/devices/{deviceId}", null)
+        {
+        }
+    }
+}

--- a/src/FibaroDotNetSDK/Devices/IDeviceGateway.cs
+++ b/src/FibaroDotNetSDK/Devices/IDeviceGateway.cs
@@ -8,6 +8,7 @@ namespace FibaroDotNetSDK.Devices
     public interface IDeviceGateway
     {
         Task<ICollection<Device>> GetDevices();
+        Task<Device> GetDeviceById(int deviceId);
 
         Task Call(long id, DeviceAction action);
     }

--- a/src/FibaroDotNetSDK/FibaroDotNetSDK.csproj
+++ b/src/FibaroDotNetSDK/FibaroDotNetSDK.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageProjectUrl>https://github.com/onpaj/FibaroDotNET</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/FibaroDotNet.Tests/HomeCenterTests.cs
+++ b/test/FibaroDotNet.Tests/HomeCenterTests.cs
@@ -28,6 +28,20 @@ namespace FibaroDotNet.Tests
         }
 
         [Fact]
+        public async Task GetDeviceById()
+        {
+            var settings = TestHelper.GetSettings();
+
+
+            var client = new FibaroClient(settings);
+
+            var gw = new DeviceGateway(client);
+            var entities = await gw.GetDeviceById(1);
+
+            Assert.NotNull(entities);
+        }
+
+        [Fact]
         public async Task GetRooms()
         {
             var settings = TestHelper.GetSettings();


### PR DESCRIPTION
Add API command to load a specific device by device id.
Reduce the load on the gateway for frequent query of the same device.